### PR TITLE
fix: make sure all accounts opened before send Tx

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	client, err := qlcchain.NewQLCClient("")
+	client, err := qlcchain.NewQLCClient("ws://127.0.0.1:9736")
 	if err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
- make sure all accounts opened before send Tx
- fix receive timer tick

Signed-off-by: Goren <yong.gu@qlink.mobi>

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/qlc.go/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/qlc.go/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A
